### PR TITLE
Introduce Twitter Card Metadata into Image Template

### DIFF
--- a/templates/display/image.html
+++ b/templates/display/image.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block head %}
+<meta name="twitter:card" content="summary_large_image">
 <meta property="og:image" content="{{ siteurl }}{{ sitepath }}{{ selifpath }}{{ filename }}" />
 {% endblock %}
 


### PR DESCRIPTION
Original PR at https://github.com/andreimarcu/linx-server/pull/269

When I posted a URL to an image on a platform like Discord (Which uses Twitter's card meta API), I noticed that it didn't look that great:

![image](https://user-images.githubusercontent.com/15330699/125178223-a9a1b780-e1da-11eb-9147-cba660da8e78.png)

Simply adding a tag to specify that this should be presented as a Twitter embed with a large image (That is, an image that is featured prominently) makes it look much better:

![image](https://user-images.githubusercontent.com/15330699/125178239-cdfd9400-e1da-11eb-84da-158eceb1ffa7.png)
