### PR TITLE
add default expiry config parameter

### DIFF
--- a/pages.go
+++ b/pages.go
@@ -21,9 +21,10 @@ const (
 
 func indexHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 	err := renderTemplate(Templates["index.html"], pongo2.Context{
-		"maxsize":     Config.maxSize,
-		"expirylist":  listExpirationTimes(),
-		"forcerandom": Config.forceRandomFilename,
+		"maxsize":       Config.maxSize,
+		"expirylist":    listExpirationTimes(),
+		"expirydefault": Config.defaultExpiry,
+		"forcerandom":   Config.forceRandomFilename,
 	}, r, w)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -32,8 +33,9 @@ func indexHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 
 func pasteHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 	err := renderTemplate(Templates["paste.html"], pongo2.Context{
-		"expirylist":  listExpirationTimes(),
-		"forcerandom": Config.forceRandomFilename,
+		"expirylist":    listExpirationTimes(),
+		"expirydefault": Config.defaultExpiry,
+		"forcerandom":   Config.forceRandomFilename,
 	}, r, w)
 	if err != nil {
 		oopsHandler(c, w, r, RespHTML, "")

--- a/server.go
+++ b/server.go
@@ -56,6 +56,7 @@ var Config struct {
 	xFrameOptions             string
 	maxSize                   int64
 	maxExpiry                 uint64
+	defaultExpiry             uint64
 	realIp                    bool
 	noLogs                    bool
 	allowHotlink              bool
@@ -264,6 +265,8 @@ func main() {
 		"maximum upload file size in bytes (default 4GB)")
 	flag.Uint64Var(&Config.maxExpiry, "maxexpiry", 0,
 		"maximum expiration time in seconds (default is 0, which is no expiry)")
+	flag.Uint64Var(&Config.defaultExpiry, "default-expiry", 86400,
+		"default expiration time in seconds (default is 86400, which is 1 day)")
 	flag.StringVar(&Config.certFile, "certfile", "",
 		"path to ssl certificate (for https)")
 	flag.StringVar(&Config.keyFile, "keyfile", "",

--- a/templates/base.html
+++ b/templates/base.html
@@ -30,7 +30,7 @@
 
 			{% block content %}{% endblock %}
 			<div id="footer">
-				<p>{{ extra_footer_text }}  </p><a href="https://github.com/andreimarcu/linx-server">linx-server</a>
+				<p>{{ extra_footer_text }}  </p><a href="https://github.com/zizzydizzymc/linx-server">linx-server</a>
 			</div>
 
 		</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,7 @@
                 <label>File expiry:
                     <select name="expires" id="expires">
                         {% for expiry in expirylist %}
-                        <option value="{{ expiry.Seconds }}" {% if forloop.Last %} selected{% endif %}>
+                        <option value="{{ expiry.Seconds }}" {% if (expiry.Seconds == expirydefault) %} selected {% endif %}>
                             {{ expiry.Human }}</option>
                         {% endfor %}
                     </select>

--- a/templates/paste.html
+++ b/templates/paste.html
@@ -22,7 +22,7 @@
                 <select id="expiry" name="expires">
                     <option disabled>Expires:</option>
                     {% for expiry in expirylist %}
-                    <option value="{{ expiry.Seconds }}" {% if forloop.Last %} selected{% endif %}>{{ expiry.Human }}
+                    <option value="{{ expiry.Seconds }}" {% if (expiry.Seconds == expirydefault) %} selected {% endif %}>{{ expiry.Human }}
                     </option>
                     {% endfor %}
                 </select>


### PR DESCRIPTION
Small update that adds `default-expiry` to the `linx-server.conf` parameters.

Example **linx-server.conf** - no limit to expiry, default = 1 day:
```
maxexpiry = 0
default-expiry = 86400
```

Previously, the default expiry would always == max expiry, which is not always desired...