### PR TITLE
Don't randomize filename if Linx-Randomize is not "yes"

### DIFF
--- a/upload.go
+++ b/upload.go
@@ -229,6 +229,8 @@ func uploadRemote(c web.C, w http.ResponseWriter, r *http.Request) {
 func uploadHeaderProcess(r *http.Request, upReq *UploadRequest) {
 	if r.Header.Get("Linx-Randomize") == "yes" {
 		upReq.randomBarename = true
+	} else {
+		upReq.randomBarename = false
 	}
 	upReq.deleteKey = r.Header.Get("Linx-Delete-Key")
 	upReq.accessKey = r.Header.Get(accessKeyHeaderName)


### PR DESCRIPTION
Without this fix, if you do `curl -v -T a.png https://linx.example.com/upload/`, then the filename is randomized, even without setting the `Linx-Randomize` header to `yes`. With this fix, the previous command won't use a randomized filename, but `curl -v -T a.png -H 'Linx-Randomize: yes' https://linx.example.com/upload/` will.