### PR TITLE
Lock files while they're being written

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,11 @@ ENV SSL_CERT_FILE /etc/ssl/cert.pem
 COPY static /go/src/github.com/andreimarcu/linx-server/static/
 COPY templates /go/src/github.com/andreimarcu/linx-server/templates/
 
-RUN mkdir -p /data/files && mkdir -p /data/meta && chown -R 65534:65534 /data
+RUN mkdir -p /data/files && mkdir -p /data/meta && mkdir -p /data/locks && chown -R 65534:65534 /data
 
-VOLUME ["/data/files", "/data/meta"]
+VOLUME ["/data/files", "/data/meta", "/data/locks"]
 
 EXPOSE 8080
 USER nobody
-ENTRYPOINT ["/usr/local/bin/linx-server", "-bind=0.0.0.0:8080", "-filespath=/data/files/", "-metapath=/data/meta/"]
+ENTRYPOINT ["/usr/local/bin/linx-server", "-bind=0.0.0.0:8080", "-filespath=/data/files/", "-metapath=/data/meta/", "-lockspath=/data/locks/"]
 CMD ["-sitename=linx", "-allowhotlink"]

--- a/backends/localfs/localfs.go
+++ b/backends/localfs/localfs.go
@@ -16,6 +16,7 @@ import (
 type LocalfsBackend struct {
 	metaPath  string
 	filesPath string
+	locksPath string
 }
 
 type MetadataJSON struct {
@@ -127,6 +128,29 @@ func (b LocalfsBackend) writeMetadata(key string, metadata backends.Metadata) er
 	return nil
 }
 
+func (b LocalfsBackend) Lock(filename string) (err error) {
+	lockPath := path.Join(b.locksPath, filename)
+
+	lock, err := os.Create(lockPath)
+	if err != nil {
+		return err
+	}
+
+	lock.Close()
+	return
+}
+
+func (b LocalfsBackend) Unlock(filename string) (err error) {
+	lockPath := path.Join(b.locksPath, filename)
+
+	err = os.Remove(lockPath)
+	if err != nil {
+		return err
+	}
+
+	return
+}
+
 func (b LocalfsBackend) Put(key string, r io.Reader, expiry time.Time, deleteKey, accessKey string, srcIp string) (m backends.Metadata, err error) {
 	filePath := path.Join(b.filesPath, key)
 
@@ -201,9 +225,10 @@ func (b LocalfsBackend) List() ([]string, error) {
 	return output, nil
 }
 
-func NewLocalfsBackend(metaPath string, filesPath string) LocalfsBackend {
+func NewLocalfsBackend(metaPath string, filesPath string, locksPath string) LocalfsBackend {
 	return LocalfsBackend{
 		metaPath:  metaPath,
 		filesPath: filesPath,
+		locksPath: locksPath,
 	}
 }

--- a/backends/localfs/localfs.go
+++ b/backends/localfs/localfs.go
@@ -2,6 +2,7 @@ package localfs
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -149,6 +150,18 @@ func (b LocalfsBackend) Unlock(filename string) (err error) {
 	}
 
 	return
+}
+
+func (b LocalfsBackend) CheckLock(filename string) (locked bool, err error) {
+	lockPath := path.Join(b.locksPath, filename)
+
+	if _, err := os.Stat(lockPath); errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	} else {
+		return true, nil
+	}
+
+	return false, err
 }
 
 func (b LocalfsBackend) Put(key string, r io.Reader, expiry time.Time, deleteKey, accessKey string, srcIp string) (m backends.Metadata, err error) {

--- a/backends/s3/s3.go
+++ b/backends/s3/s3.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -153,6 +154,16 @@ func unmapMetadata(input map[string]*string) (m backends.Metadata, err error) {
 		m.AccessKey = aws.StringValue(key)
 	}
 
+	return
+}
+
+func (b S3Backend) Lock(filename string) (err error) {
+	log.Printf("Locking is not supported on S3")
+	return
+}
+
+func (b S3Backend) Unlock(filename string) (err error) {
+	log.Printf("Locking is not supported on S3")
 	return
 }
 

--- a/backends/s3/s3.go
+++ b/backends/s3/s3.go
@@ -167,6 +167,11 @@ func (b S3Backend) Unlock(filename string) (err error) {
 	return
 }
 
+func (b S3Backend) CheckLock(filename string) (locked bool, err error) {
+	log.Printf("Locking is not supported on S3")
+	return
+}
+
 func (b S3Backend) Put(key string, r io.Reader, expiry time.Time, deleteKey, accessKey string, srcIp string) (m backends.Metadata, err error) {
 	tmpDst, err := ioutil.TempFile("", "linx-server-upload")
 	if err != nil {

--- a/backends/storage.go
+++ b/backends/storage.go
@@ -14,6 +14,7 @@ type StorageBackend interface {
 	Get(key string) (Metadata, io.ReadCloser, error)
 	Lock(filename string) (error)
 	Unlock(filename string) (error)
+	CheckLock(filename string) (bool, error)
 	Put(key string, r io.Reader, expiry time.Time, deleteKey, accessKey string, srcIp string) (Metadata, error)
 	PutMetadata(key string, m Metadata) error
 	ServeFile(key string, w http.ResponseWriter, r *http.Request) error
@@ -27,4 +28,3 @@ type MetaStorageBackend interface {
 
 var NotFoundErr = errors.New("File not found.")
 var FileEmptyError = errors.New("Empty file")
-var FileLockedError = errors.New("Locked file")

--- a/backends/storage.go
+++ b/backends/storage.go
@@ -12,6 +12,8 @@ type StorageBackend interface {
 	Exists(key string) (bool, error)
 	Head(key string) (Metadata, error)
 	Get(key string) (Metadata, io.ReadCloser, error)
+	Lock(filename string) (error)
+	Unlock(filename string) (error)
 	Put(key string, r io.Reader, expiry time.Time, deleteKey, accessKey string, srcIp string) (Metadata, error)
 	PutMetadata(key string, m Metadata) error
 	ServeFile(key string, w http.ResponseWriter, r *http.Request) error
@@ -25,3 +27,4 @@ type MetaStorageBackend interface {
 
 var NotFoundErr = errors.New("File not found.")
 var FileEmptyError = errors.New("Empty file")
+var FileLockedError = errors.New("Locked file")

--- a/cleanup/cleanup.go
+++ b/cleanup/cleanup.go
@@ -8,8 +8,8 @@ import (
 	"github.com/andreimarcu/linx-server/expiry"
 )
 
-func Cleanup(filesDir string, metaDir string, noLogs bool) {
-	fileBackend := localfs.NewLocalfsBackend(metaDir, filesDir)
+func Cleanup(filesDir string, metaDir string, locksDir string, noLogs bool) {
+	fileBackend := localfs.NewLocalfsBackend(metaDir, filesDir, locksDir)
 
 	files, err := fileBackend.List()
 	if err != nil {
@@ -33,10 +33,10 @@ func Cleanup(filesDir string, metaDir string, noLogs bool) {
 	}
 }
 
-func PeriodicCleanup(minutes time.Duration, filesDir string, metaDir string, noLogs bool) {
+func PeriodicCleanup(minutes time.Duration, filesDir string, metaDir string, locksDir string, noLogs bool) {
 	c := time.Tick(minutes)
 	for range c {
-		Cleanup(filesDir, metaDir, noLogs)
+		Cleanup(filesDir, metaDir, locksDir, noLogs)
 	}
 
 }

--- a/cleanup/cleanup.go
+++ b/cleanup/cleanup.go
@@ -17,6 +17,15 @@ func Cleanup(filesDir string, metaDir string, locksDir string, noLogs bool) {
 	}
 
 	for _, filename := range files {
+		locked, err := fileBackend.CheckLock(filename)
+		if err != nil {
+			log.Printf("Error checking if %s is locked: %s", filename, err)
+		}
+		if locked {
+			log.Printf("%s is locked, it will be ignored", filename)
+			continue
+		}
+
 		metadata, err := fileBackend.Head(filename)
 		if err != nil {
 			if !noLogs {
@@ -36,7 +45,9 @@ func Cleanup(filesDir string, metaDir string, locksDir string, noLogs bool) {
 func PeriodicCleanup(minutes time.Duration, filesDir string, metaDir string, locksDir string, noLogs bool) {
 	c := time.Tick(minutes)
 	for range c {
+		log.Printf("Running periodic cleanup")
 		Cleanup(filesDir, metaDir, locksDir, noLogs)
+		log.Printf("Finished periodic cleanup")
 	}
 
 }

--- a/csp_test.go
+++ b/csp_test.go
@@ -20,6 +20,7 @@ func TestContentSecurityPolicy(t *testing.T) {
 	Config.siteURL = "http://linx.example.org/"
 	Config.filesDir = path.Join(os.TempDir(), generateBarename())
 	Config.metaDir = Config.filesDir + "_meta"
+	Config.locksDir = Config.filesDir + "_locks"
 	Config.maxSize = 1024 * 1024 * 1024
 	Config.noLogs = true
 	Config.siteName = "linx"

--- a/linx-cleanup/linx-cleanup.go
+++ b/linx-cleanup/linx-cleanup.go
@@ -16,11 +16,11 @@ func main() {
 		"path to files directory")
 	flag.StringVar(&metaDir, "metapath", "meta/",
 		"path to metadata directory")
-	flag.StringVar(&metaDir, "lockspath", "locks/",
-		"path to metadata directory")
+	flag.StringVar(&locksDir, "lockspath", "locks/",
+		"path to locks directory")
 	flag.BoolVar(&noLogs, "nologs", false,
 		"don't log deleted files")
 	flag.Parse()
 
-	cleanup.Cleanup(filesDir, metaDir, noLogs)
+	cleanup.Cleanup(filesDir, metaDir, locksDir, noLogs)
 }

--- a/linx-cleanup/linx-cleanup.go
+++ b/linx-cleanup/linx-cleanup.go
@@ -9,11 +9,14 @@ import (
 func main() {
 	var filesDir string
 	var metaDir string
+	var locksDir string
 	var noLogs bool
 
 	flag.StringVar(&filesDir, "filespath", "files/",
 		"path to files directory")
 	flag.StringVar(&metaDir, "metapath", "meta/",
+		"path to metadata directory")
+	flag.StringVar(&metaDir, "lockspath", "locks/",
 		"path to metadata directory")
 	flag.BoolVar(&noLogs, "nologs", false,
 		"don't log deleted files")

--- a/server.go
+++ b/server.go
@@ -138,7 +138,7 @@ func setup() *web.Mux {
 		log.Fatal("Could not create metadata directory:", err)
 	}
 
-	err = os.MkdirAll(Config.locksDir, 0700)
+	err = os.MkdirAll(Config.locksDir, 0755)
 	if err != nil {
 		log.Fatal("Could not create locks directory:", err)
 	}

--- a/server.go
+++ b/server.go
@@ -256,7 +256,7 @@ func main() {
 	flag.StringVar(&Config.metaDir, "metapath", "meta/",
 		"path to metadata directory")
 	flag.StringVar(&Config.locksDir, "lockspath", "locks/",
-		"path to metadata directory")
+		"path to locks directory")
 	flag.BoolVar(&Config.basicAuth, "basicauth", false,
 		"allow logging by basic auth password")
 	flag.BoolVar(&Config.noLogs, "nologs", false,

--- a/server_test.go
+++ b/server_test.go
@@ -33,6 +33,7 @@ func TestSetup(t *testing.T) {
 	Config.siteURL = "http://linx.example.org/"
 	Config.filesDir = path.Join(os.TempDir(), generateBarename())
 	Config.metaDir = Config.filesDir + "_meta"
+	Config.locksDir = Config.filesDir + "_locks"
 	Config.maxSize = 1024 * 1024 * 1024
 	Config.noLogs = true
 	Config.siteName = "linx"
@@ -1255,6 +1256,7 @@ func TestInferSiteURLHTTPSFastCGI(t *testing.T) {
 func TestShutdown(t *testing.T) {
 	os.RemoveAll(Config.filesDir)
 	os.RemoveAll(Config.metaDir)
+	os.RemoveAll(Config.locksDir)
 }
 
 func TestPutAndGetCLI(t *testing.T) {


### PR DESCRIPTION
Fixes #16 

This prevents a file from being deleted in the middle of being uploaded if a cleanup runs while the file is being written.