### PR TITLE
Push docker images to ghcr

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,22 +14,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Prepare
-        id: prepare
-        run: |
-          DOCKER_IMAGE=ghcr.io/${{ github.repository_owner }}/linx-server
-          DOCKER_PLATFORMS=linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/386
-          VERSION=${GITHUB_REF#refs/tags/v}
-          TAGS="--tag ${DOCKER_IMAGE}:${VERSION} --tag ${DOCKER_IMAGE}:latest --tag ${DOCKER_IMAGE}:${GITHUB_SHA::8}"
-
-          echo ::set-output name=docker_image::${DOCKER_IMAGE}
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=buildx_args::--platform ${DOCKER_PLATFORMS} \
-            --build-arg VERSION=${VERSION} \
-            --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
-            --build-arg VCS_REF=${GITHUB_SHA::8} \
-            ${TAGS} --file Dockerfile .
-
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/linx-server
+      
       - name: Login to GHCR
         uses: docker/login-action@v2
         if: github.event_name != 'pull_request'
@@ -38,12 +28,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: crazy-max/ghaction-docker-buildx@v3
-
-      - name: Docker Buildx (build)
-        run: docker buildx build --output "type=image,push=false" ${{ steps.prepare.outputs.buildx_args }}
-      
-      - name: Docker Buildx (push)
-        if: success()
-        run: docker buildx build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: buildx
+name: build
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
       - 'v*'
 
 jobs:
-  buildx:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/buildx.yaml
+++ b/.github/workflows/buildx.yaml
@@ -2,6 +2,8 @@ name: buildx
 
 on:
   push:
+    branches:
+      - master
     tags:
       - 'v*'
 
@@ -9,17 +11,16 @@ jobs:
   buildx:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
-      -
-        name: Prepare
+
+      - name: Prepare
         id: prepare
         run: |
-          DOCKER_IMAGE=andreimarcu/linx-server
+          DOCKER_IMAGE=ghcr.io/${{ github.repository_owner }}/linx-server
           DOCKER_PLATFORMS=linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/386
-          VERSION=version-${GITHUB_REF#refs/tags/v}
-          TAGS="--tag ${DOCKER_IMAGE}:${VERSION} --tag ${DOCKER_IMAGE}:latest"
+          VERSION=${GITHUB_REF#refs/tags/v}
+          TAGS="--tag ${DOCKER_IMAGE}:${VERSION} --tag ${DOCKER_IMAGE}:latest --tag ${DOCKER_IMAGE}:${GITHUB_SHA::8}"
 
           echo ::set-output name=docker_image::${DOCKER_IMAGE}
           echo ::set-output name=version::${VERSION}
@@ -28,33 +29,21 @@ jobs:
             --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
             --build-arg VCS_REF=${GITHUB_SHA::8} \
             ${TAGS} --file Dockerfile .
-      -
-        name: Set up Docker Buildx
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
         uses: crazy-max/ghaction-docker-buildx@v3
-      -
-        name: Docker Buildx (build)
-        run: |
-          docker buildx build --output "type=image,push=false" ${{ steps.prepare.outputs.buildx_args }}
-      -
-        name: Docker Login
+
+      - name: Docker Buildx (build)
+        run: docker buildx build --output "type=image,push=false" ${{ steps.prepare.outputs.buildx_args }}
+      
+      - name: Docker Buildx (push)
         if: success()
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
-      -
-        name: Docker Buildx (push)
-        if: success()
-        run: |
-          docker buildx build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
-      -
-        name: Docker Check Manifest
-        if: always()
-        run: |
-          docker run --rm mplatform/mquery ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
-      -
-        name: Clear
-        if: always()
-        run: |
-          rm -f ${HOME}/.docker/config.json
+        run: docker buildx build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}


### PR DESCRIPTION
This change adds a github actions workflow to build the docker images and push them to github's built-in container registry.