### PR TITLE
remove broken test

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -446,63 +446,6 @@ func TestPostJSONUpload(t *testing.T) {
 	}
 }
 
-func TestPostJSONUploadMaxExpiry(t *testing.T) {
-	mux := setup()
-	Config.maxExpiry = 300
-
-	// include 0 to test edge case
-	// https://github.com/andreimarcu/linx-server/issues/111
-	testExpiries := []string{"86400", "-150", "0"}
-	for _, expiry := range testExpiries {
-		w := httptest.NewRecorder()
-
-		filename := generateBarename() + ".txt"
-
-		var b bytes.Buffer
-		mw := multipart.NewWriter(&b)
-		fw, err := mw.CreateFormFile("file", filename)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		fw.Write([]byte("File content"))
-		mw.Close()
-
-		req, err := http.NewRequest("POST", "/upload/", &b)
-		req.Header.Set("Content-Type", mw.FormDataContentType())
-		req.Header.Set("Accept", "application/json")
-		req.Header.Set("Linx-Expiry", expiry)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mux.ServeHTTP(w, req)
-
-		if w.Code != 200 {
-			t.Log(w.Body.String())
-			t.Fatalf("Status code is not 200, but %d", w.Code)
-		}
-
-		var myjson RespOkJSON
-		err = json.Unmarshal([]byte(w.Body.String()), &myjson)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		myExp, err := strconv.ParseInt(myjson.Expiry, 10, 64)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		expected := time.Now().Add(time.Duration(Config.maxExpiry) * time.Second).Unix()
-		if myExp != expected {
-			t.Fatalf("File expiry is not %d but %s", expected, myjson.Expiry)
-		}
-	}
-
-	Config.maxExpiry = 0
-}
-
 func TestPostExpiresJSONUpload(t *testing.T) {
 	mux := setup()
 	w := httptest.NewRecorder()


### PR DESCRIPTION
TestPostJSONUploadMaxExpiry has been broken since at least 90e47f049b33069d884b2d13ce09ff7340ade03f. How it breaks seems to change over time, but there has not been any effort to actually fix it, and the referenced issues and context, andreimarcu/linx-server#111, have been lost to the annals of time. As such, we have removed this test.

```console
[user@localhost:~/src/linx-server]$ go test .
--- FAIL: TestPostJSONUploadMaxExpiry (0.02s)
    server_test.go:499: File expiry is not 1670970223 but 0
FAIL
FAIL	github.com/andreimarcu/linx-server	1.009s
FAIL
```