### PR TITLE
Update Dockerfile's Go & Alpine versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM golang:1.14-alpine3.11 AS build
+FROM golang:1.22-alpine3.20 AS build
 
 COPY . /go/src/github.com/andreimarcu/linx-server
 WORKDIR /go/src/github.com/andreimarcu/linx-server
 
 RUN set -ex \
         && apk add --no-cache --virtual .build-deps git \
-        && go get -v . \
+	&& go install -v . \
         && apk del .build-deps
 
-FROM alpine:3.11
+FROM alpine:3.20
 
 COPY --from=build /go/bin/linx-server /usr/local/bin/linx-server
 
@@ -18,7 +18,9 @@ ENV SSL_CERT_FILE /etc/ssl/cert.pem
 COPY static /go/src/github.com/andreimarcu/linx-server/static/
 COPY templates /go/src/github.com/andreimarcu/linx-server/templates/
 
-RUN mkdir -p /data/files && mkdir -p /data/meta && mkdir -p /data/locks && chown -R 65534:65534 /data
+RUN mkdir -p /data/files /data/meta /data/locks \
+        && chown -R 65534:65534 /data \
+        && chmod -R u=rwX,go=rX /go/src/github.com/andreimarcu/linx-server
 
 VOLUME ["/data/files", "/data/meta", "/data/locks"]
 


### PR DESCRIPTION
Update Go to 1.22 and Alpine to 3.20 and change Dockerfile accordingly.

Add `go build` command.
Run `chmod` on `/go/src/github.com/andreimarcu/linx-server` to make static & templates directories readable by the server (only needed when image is built with UMASK=0027).