### PR TITLE
Fixes #30 and updated the Dockerfile since it fails to build and compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ meta/
 binaries/
 custom_pages/
 authfile
+_data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
-FROM golang:1.14-alpine3.11 AS build
+FROM golang:1.22.4-alpine3.20 AS build
 
 COPY . /go/src/github.com/andreimarcu/linx-server
 WORKDIR /go/src/github.com/andreimarcu/linx-server
 
 RUN set -ex \
         && apk add --no-cache --virtual .build-deps git \
-        && go get -v . \
+        && go mod download \
+        && go build -o /go/bin/linx-server . \
         && apk del .build-deps
 
-FROM alpine:3.11
+FROM alpine:3.20
 
 COPY --from=build /go/bin/linx-server /usr/local/bin/linx-server
 
@@ -18,11 +19,11 @@ ENV SSL_CERT_FILE /etc/ssl/cert.pem
 COPY static /go/src/github.com/andreimarcu/linx-server/static/
 COPY templates /go/src/github.com/andreimarcu/linx-server/templates/
 
-RUN mkdir -p /data/files && mkdir -p /data/meta && mkdir -p /data/locks && chown -R 65534:65534 /data
+RUN mkdir -p /data/files && mkdir -p /data/meta && mkdir -p /data/locks && mkdir -p /data/custom_pages && chown -R 65534:65534 /data
 
-VOLUME ["/data/files", "/data/meta", "/data/locks"]
+VOLUME ["/data/files", "/data/meta", "/data/locks", "/data/custom_pages"]
 
 EXPOSE 8080
 USER nobody
-ENTRYPOINT ["/usr/local/bin/linx-server", "-bind=0.0.0.0:8080", "-filespath=/data/files/", "-metapath=/data/meta/", "-lockspath=/data/locks/"]
+ENTRYPOINT ["/usr/local/bin/linx-server", "-bind=0.0.0.0:8080", "-filespath=/data/files/", "-metapath=/data/meta/", "-lockspath=/data/locks/", "-custompagespath=/data/custom_pages"]
 CMD ["-sitename=linx", "-allowhotlink"]

--- a/README.md
+++ b/README.md
@@ -1,94 +1,89 @@
-linx-server 
-======
+# linx-server
 
 Self-hosted file/media sharing website.  
 
-### Is this still active?
+## Is this still active?
 
 Yes, though the repo may be old, it's still active and I'll try and fix any major issues that occur with my limited time.
 
-### Demo
-You can see what it looks like using the demo: [https://put.icu/](https://put.icu/)
+## Demo
 
+You can see what it looks like using the demo: [https://put.icu/](https://put.icu/). _(IMPORTANT NOTICE: this demo isn't mine, and it's not running the latest updates of this repo)_
 
-### Clients
-**Official**
+## Clients
+
+### Official
+
 - CLI: **linx-client** - [Source](https://github.com/andreimarcu/linx-client)
 
-**Unofficial**
+### Unofficial
+
 - Android: **LinxShare** - [Source](https://github.com/iksteen/LinxShare/) | [Google Play](https://play.google.com/store/apps/details?id=org.thegraveyard.linxshare)
 - CLI: **golinx** - [Source](https://github.com/mutantmonkey/golinx)
 
+## Features
 
-### Features
+- Display common filetypes (image, video, audio, markdown, pdf).
+- Display syntax-highlighted code with in-place editing.
+- Documented API with keys for restricting uploads.
+- Torrent download of files using web seeding.
+- File expiry, deletion key, file access key, and random filename options.
 
-- Display common filetypes (image, video, audio, markdown, pdf)  
-- Display syntax-highlighted code with in-place editing
-- Documented API with keys for restricting uploads
-- Torrent download of files using web seeding
-- File expiry, deletion key, file access key, and random filename options
+## Screenshots
 
-
-### Screenshots
 <img width="730" src="https://user-images.githubusercontent.com/4650950/76579039-03c82680-6488-11ea-8e23-4c927386fbd9.png" />
 
 <img width="180" src="https://user-images.githubusercontent.com/4650950/76578903-771d6880-6487-11ea-8baf-a4a23fef4d26.png" /> <img width="180" src="https://user-images.githubusercontent.com/4650950/76578910-7be21c80-6487-11ea-9a0a-587d59bc5f80.png" /> <img width="180" src="https://user-images.githubusercontent.com/4650950/76578908-7b498600-6487-11ea-8994-ee7b6eb9cdb1.png" /> <img width="180" src="https://user-images.githubusercontent.com/4650950/76578907-7b498600-6487-11ea-8941-8f582bf87fb0.png" />
 
+## Getting started
 
-Getting started
--------------------
+### Using Docker or Docker Compose
 
-#### Using Docker
-1. Create directories ```files``` and ```meta``` and run ```chown -R 65534:65534 meta && chown -R 65534:65534 files``` 
-2. Create a config file (example provided in repo), we'll refer to it as __linx-server.conf__ in the following examples
+1. Create a directory named `_data` and change its ownership `chown -R 65534:65534 _data` (`65534` is the `nobody` user & group).
+2. Create a config file named `linx-server.conf` (check [linx-server.conf.example](linx-server.conf.example)) inside that `_data` directory.
 
+#### Docker
 
-
-Example running
+```sh
+docker run -p 8080:8080 -v ./_data/linx-server.conf:/data/linx-server.conf -v ./_data/meta:/data/meta -v ./_data/files:/data/files -v ./_data/custom_pages:/data/custom_pages ghcr.io/m-primo/linx-server:latest -config /data/linx-server.conf
 ```
-docker run -p 8080:8080 -v /path/to/linx-server.conf:/data/linx-server.conf -v /path/to/meta:/data/meta -v /path/to/files:/data/files andreimarcu/linx-server -config /data/linx-server.conf
-``` 
 
-Example with docker-compose 
+#### Docker Compose
+
+Check [compose.yml](compose.yml), update it and remove this block:
+
+```yml
+build:
+  context: .
 ```
-version: '2.2'
-services:
-  linx-server:
-    container_name: linx-server
-    image: andreimarcu/linx-server
-    command: -config /data/linx-server.conf
-    volumes:
-      - /path/to/files:/data/files
-      - /path/to/meta:/data/meta
-      - /path/to/linx-server.conf:/data/linx-server.conf
-    network_mode: bridge
-    ports:
-      - "8080:8080"
-    restart: unless-stopped
-```
-Ideally, you would use a reverse proxy such as nginx or caddy to handle TLS certificates.
 
-#### Using a binary release
+Then change the `image` value from `m-primo/linx-server:latest` to `ghcr.io/m-primo/linx-server:latest`.
 
-1. Grab the latest binary from the [releases](https://github.com/andreimarcu/linx-server/releases), then run ```go install```
-2. Run ```linx-server -config path/to/linx-server.conf```
+### Using a binary release
 
-  
-Usage
------
+1. Download the latest binary from the [releases](https://github.com/m-primo/linx-server/releases).
+2. Extract the archive `tar -xvzf linx-server.tar.gz`.
+3. Run ```linx.sh -config /path/to/linx-server.conf```.
 
-#### Configuration
+Ideally, you would use a reverse proxy such as Nginx, Caddy, or Apache to handle TLS certificates and act as a high performance web server.
+
+## Usage
+
+### Configuration
+
 All configuration options are accepted either as arguments or can be placed in a file as such (see example file linx-server.conf.example in repo):  
+
 ```ini
 bind = 127.0.0.1:8080
 sitename = myLinx
 maxsize = 4294967296
 maxexpiry = 86400
 # ... etc
-``` 
-...and then run ```linx-server -config path/to/linx-server.conf```    
+```
 
-#### Options
+...and then run ```linx-server -config path/to/linx-server.conf```
+
+### Options
 
 |Option|Description
 |------|-----------
@@ -113,18 +108,16 @@ maxexpiry = 86400
 | ```max-duration-size = 4294967296``` | Size of file before max-duration-time is used to determine expiry max time. (Default is 4GB)
 | ```disable-access-key = true``` | Disables access key usage. (Default is false.)
 | ```default-random-filename = true``` | Makes it so the random filename is not default if set false. (Default is true.)
-| ```strict-site-url = true``` | Enforces strict site URL format for CSRF protection. (Default is true.)
-
+| ```strict-site-url = true``` | Enforces strict site URL format for CSRF protection. (Default is true.) - Useful if you access the website on multiple domains and IPs.
 
 #### Cleaning up expired files
+
 When files expire, access is disabled immediately, but the files and metadata
 will persist on disk until someone attempts to access them. You can set the following option to run cleanup every few minutes. This can also be done using a separate utility found the linx-cleanup directory.
-
 
 |Option|Description
 |------|-----------
 | ```cleanup-every-minutes = 5``` | How often to clean up expired files in minutes (default is 0, which means files will be cleaned up as they are accessed)
-
 
 #### Require API Keys for uploads
 
@@ -137,6 +130,7 @@ will persist on disk until someone attempts to access them. You can set the foll
 A helper utility ```linx-genkey``` is provided which hashes keys to the format required in the auth files.
 
 #### Storage backends
+
 The following storage backends are available:
 
 |Name|Notes|Options
@@ -144,66 +138,90 @@ The following storage backends are available:
 |LocalFS|Enabled by default, this backend uses the filesystem|```filespath = files/``` -- Path to store uploads (default is files/)<br />```metapath = meta/``` -- Path to store information about uploads (default is meta/)|
 |S3|Use with any S3-compatible provider.<br> This implementation will stream files through the linx instance (every download will request and stream the file from the S3 bucket). File metadata will be stored as tags on the object in the bucket.<br><br>For high-traffic environments, one might consider using an external caching layer such as described [in this article](https://blog.sentry.io/2017/03/01/dodging-s3-downtime-with-nginx-and-haproxy.html).|```s3-endpoint = https://...``` -- S3 endpoint<br>```s3-region = us-east-1``` -- S3 region<br>```s3-bucket = mybucket``` -- S3 bucket to use for files and metadata<br>```s3-force-path-style = true``` (optional) -- force path-style addresing (e.g. https://<span></span>s3.amazonaws.com/linx/example.txt)<br><br>Environment variables to provide:<br>```AWS_ACCESS_KEY_ID``` -- the S3 access key<br>```AWS_SECRET_ACCESS_KEY ``` -- the S3 secret key<br>```AWS_SESSION_TOKEN``` (optional) -- the S3 session token|
 
+#### SSL with built-in server
 
-#### SSL with built-in server 
 |Option|Description
 |------|-----------
 | ```certfile = path/to/your.crt``` | Path to the ssl certificate (required if you want to use the https server)
 | ```keyfile = path/to/your.key``` | Path to the ssl key (required if you want to use the https server)
 
-#### Use with http proxy 
+#### Use with http proxy
+
 |Option|Description
 |------|-----------
 | ```realip = true``` | let linx-server know you (nginx, etc) are providing the X-Real-IP and/or X-Forwarded-For headers.
 
 #### Use with fastcgi
+
 |Option|Description
 |------|-----------
 | ```fastcgi = true``` | serve through fastcgi 
 
-Deployment
-----------
+## Deployment
+
 Linx-server supports being deployed in a subdirectory (ie. example.com/mylinx/) as well as on its own (example.com/).
 
-
-#### 1. Using fastcgi
+### 1. Using fastcgi
 
 A suggested deployment is running nginx in front of linx-server serving through fastcgi.
 This allows you to have nginx handle the TLS termination for example.  
 An example configuration:
-```
+
+```nginx
 server {
-    ...
-    server_name yourlinx.example.org;
-    ...
-    
-    client_max_body_size 4096M;
-    location / {
-        fastcgi_pass 127.0.0.1:8080;
-        include fastcgi_params;
-    }
+  ...
+  server_name yourlinx.example.org;
+  ...
+  client_max_body_size 4096M;
+  location / {
+    fastcgi_pass 127.0.0.1:8080;
+    include fastcgi_params;
+  }
 }
 ```
-And run linx-server with the ```fastcgi = true``` option.
 
-#### 2. Using the built-in https server
-Run linx-server with the ```certfile = path/to/cert.file``` and ```keyfile = path/to/key.file``` options.
+And run linx-server with the `fastcgi = true` option.
 
-#### 3. Using the built-in http server
+### 2. Using the built-in https server
+
+Run linx-server with the `certfile = path/to/cert.file` and `keyfile = path/to/key.file` options.
+
+### 3. Using the built-in http server
+
 Run linx-server normally.
 
-Development
------------
-Any help is welcome, PRs will be reviewed and merged accordingly.  
-The official IRC channel is #linx on irc.oftc.net  
+## Development
 
-1. ```go get -u github.com/andreimarcu/linx-server ```
-2. ```cd $GOPATH/src/github.com/andreimarcu/linx-server ```
-3. ```go build && ./linx-server```
+Any help is welcome, PRs will be reviewed and merged accordingly.
 
+```sh
+git pull https://github.com/m-primo/linx-server.git
+cp -r linx-server /go/src/github.com/andreimarcu/
+cd /go/src/github.com/andreimarcu/linx-server/
+go mod download
+go build -o /go/bin/linx-server .
+cp /go/bin/linx-server /usr/local/bin/linx-server
+mkdir -p /data/files && mkdir -p /data/meta && mkdir -p /data/locks && mkdir -p /data/custom_pages && chown -R 65534:65534 /data
+```
 
-License
--------
+(You might want to adjust a command or two)
+
+or using Docker.
+
+```sh
+git pull https://github.com/m-primo/linx-server.git
+docker compose build --no-cache
+docker compose up -d
+```
+
+It's better to use Docker Compose for both development and deployment, since this is my method of contributing to this project.
+
+## Upstream Project
+
+[ZizzyDizzyMC/linx-server](https://github.com/ZizzyDizzyMC/linx-server)
+
+## Original License
+
 Copyright (C) 2015 Andrei Marcu
 
 This program is free software: you can redistribute it and/or modify
@@ -219,6 +237,6 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-Author
--------
-Andrei Marcu, https://andreim.net/
+## Original Author
+
+Andrei Marcu, <https://andreim.net/>

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ maxexpiry = 86400
 | ```max-duration-size = 4294967296``` | Size of file before max-duration-time is used to determine expiry max time. (Default is 4GB)
 | ```disable-access-key = true``` | Disables access key usage. (Default is false.)
 | ```default-random-filename = true``` | Makes it so the random filename is not default if set false. (Default is true.)
+| ```strict-site-url = true``` | Enforces strict site URL format for CSRF protection. (Default is true.)
 
 
 #### Cleaning up expired files

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,16 @@
+services:
+  linx-server:
+    container_name: linx-server
+    build:
+      context: .
+    image: m-primo/linx-server:latest
+    restart: unless-stopped
+    command: -config /data/linx-server.conf
+    volumes:
+      - './_data/files:/data/files/'
+      - './_data/meta:/data/meta/'
+      - './_data/custom_pages/:/data/custom_pages/'
+      - './_data/linx.conf:/data/linx-server.conf'
+      - './_data/authfile:/data/authfile'
+    ports:
+      - '8080:8080'

--- a/linx-server.conf.example
+++ b/linx-server.conf.example
@@ -9,4 +9,5 @@ allowhotlink = true
 remoteuploads = true
 nologs = true
 force-random-filename = false
+strict-site-url = false
 cleanup-every-minutes = 5

--- a/server.go
+++ b/server.go
@@ -81,6 +81,7 @@ var Config struct {
 	maxDurationSize           int64
 	disableAccessKey          bool
 	defaultRandomFilename     bool
+	strictSiteUrl             bool
 }
 
 var Templates = make(map[string]*pongo2.Template)
@@ -328,6 +329,7 @@ func main() {
 	flag.Int64Var(&Config.maxDurationSize, "max-duration-size", 4*1024*1024*1024, "Size of file before max-duration-time is used to determine expiry max time. (Default is 4GB)")
 	flag.BoolVar(&Config.disableAccessKey, "disable-access-key", false, "Disables access key usage. (Default is false.)")
 	flag.BoolVar(&Config.defaultRandomFilename, "default-random-filename", true, "Makes it so the random filename is not default if set false. (Default is true.)")
+	flag.BoolVar(&Config.strictSiteUrl, "strict-site-url", true, "Enforces strict site URL format for CSRF protection (default is true)")
 	iniflags.Parse()
 
 	mux := setup()

--- a/upload.go
+++ b/upload.go
@@ -52,8 +52,8 @@ type Upload struct {
 }
 
 func uploadPostHandler(c web.C, w http.ResponseWriter, r *http.Request) {
-	if !strictReferrerCheck(r, getSiteURL(r), []string{"Linx-Delete-Key", "Linx-Expiry", "Linx-Randomize", "X-Requested-With"}) {
-		badRequestHandler(c, w, r, RespAUTO, "")
+	if Config.strictSiteUrl && !strictReferrerCheck(r, getSiteURL(r), []string{"Linx-Delete-Key", "Linx-Expiry", "Linx-Randomize", "X-Requested-With"}) {
+		badRequestHandler(c, w, r, RespAUTO, "CSRF mismatch")
 		return
 	}
 


### PR DESCRIPTION
As I mentioned in #30, I updated the `siteurl` issue and added a new config key called `strict-site-url`, if set to `true` it would check the `siteurl` properly and won't upload if the `siteurl` doesn't match the request url, also I added an error message instead of empty message `CSRF mismatch`, and if set to false, it would just pass that and go on and upload the file, just like the API, since the API, doesn't check for this.

This is the first key change in code (notice `Config.strictSiteUrl` and `CSRF mismatch`):

```
	if Config.strictSiteUrl && !strictReferrerCheck(r, getSiteURL(r), []string{"Linx-Delete-Key", "Linx-Expiry", "Linx-Randomize", "X-Requested-With"}) {
 		badRequestHandler(c, w, r, RespAUTO, "CSRF mismatch")
```

_I'm not sure how to reference a code from the source in here, so here's a link to this diff, <https://github.com/m-primo/linx-server/commit/0bfba9f6c91b010d94eb579664e5c680324365a0#diff-148c9bdc57383bd2555164d3c4336f2bcbe03d4edfb3a8649c7c8202260e6569R55>_

Here are screenshots:

1. After the error message update:

![Image](https://github.com/user-attachments/assets/44a04daf-ca3d-4d0b-bb31-eb14a66a7d25)

2. After setting the `siteurl` to `/`:

![Image](https://github.com/user-attachments/assets/1a06c4d0-0c6d-4387-996e-ec63bd2b4d11)

3. After setting the `siteurl` to empty string `""`:

![Image](https://github.com/user-attachments/assets/e806c8d3-128a-4abc-b952-2787344d4305)

Commit URL: <https://github.com/m-primo/linx-server/commit/0bfba9f6c91b010d94eb579664e5c680324365a0>

This was for the first change.

---

As for the second change, I have updated the Dockerfile after your commit on Go version updates since it fails to compile and build on Docker.

Commit URL: <https://github.com/m-primo/linx-server/commit/dfa11529673e7baa94a30b1bca9749c1278ada28>

---

Additionally, I added a `compose.yml` file, updated the readme, built a self-contained binary release <https://github.com/m-primo/linx-server/releases/tag/release>, and uploaded the latest updates to the GitHub Container Registry <https://github.com/m-primo/linx-server/pkgs/container/linx-server>, since there was no binary release and no public image.

---

I have tested all of this on my own machine, and I have a website on a domain and all the implemented changes are working perfectly fine. _I could send you the URL with some credentials (since its behind authentication) to test it live if you want_.

I really wish for this pull to be merged for everyone wants to run the instance on the last updates.

Thanks.